### PR TITLE
updating extension regex to parse "where" declaration

### DIFF
--- a/rubyResources/helpers.rb
+++ b/rubyResources/helpers.rb
@@ -107,7 +107,7 @@ end
 
 def allExtensions codeString
   extensions = []
-  extensionRegex = /extension\s+(?!(var|open|public|internal|fileprivate|private|func))(?<extendedEntityName>\w+)(?<protocols>([^{]*)?)(?<contentsCodeString>{(?>[^{}]|\g<contentsCodeString>)*})/
+  extensionRegex = /extension\s+(?!(var|open|public|internal|fileprivate|private|func))(?<extendedEntityName>\w+)(?<protocols>(\s*:.+?)?)(?<generics>(\s+where\s+.+?)?)(?<contentsCodeString>{(?>[^{}]|\g<contentsCodeString>)*})/
 
   codeString.scan(extensionRegex) {
     matchData = Regexp.last_match


### PR DESCRIPTION
```swift
extension Collection where Indices.Iterator.Element == Index {
}
```

should not parse ` where Indices.Iterator.Element == Index` as a protocol

See https://regex101.com/r/ZZAgB3/2 for more information