### PR TITLE
Fixed "undefined" name for extensions

### DIFF
--- a/htmltemplate/js/entity.js
+++ b/htmltemplate/js/entity.js
@@ -1,65 +1,65 @@
 
 // Fields and methods
 function itemsString(items) {
-    if (items == undefined || items.count <= 0) {
-        return "";
-    }
+  if (items == undefined || items.count <= 0) {
+    return "";
+  }
 
-    const result = items
-        .map(x => {
-            // UML private/public is denoted by +/-
-            const accessString = x.accessLevel == "public" ? "+" : "-";
+  const result = items
+    .map(x => {
+      // UML private/public is denoted by +/-
+      const accessString = x.accessLevel == "public" ? "+" : "-";
 
-            // UML static members and methods should be underlined
-            const nameString =
-                x.type == "instance" ? x.name : "_" + x.name.replace(/ /g, "_") + "_";
+      // UML static members and methods should be underlined
+      const nameString =
+        x.type == "instance" ? x.name : "_" + x.name.replace(/ /g, "_") + "_";
 
-            return accessString + " " + nameString;
-        })
-        .join("\n");
-    return result;
+      return accessString + " " + nameString;
+    })
+    .join("\n");
+  return result;
 }
 
 // { id: 3, font: { multi: 'html', size: 20 }, label: '<b>This</b> is an\n<i>html</i> <b><i>multi-</i>font</b> <code>label</code>', x: 40, y: 40 },
 function networkLabel(entity) {
-    if (entity == undefined) {
-        return "Undefined";
-    }
+  if (entity == undefined) {
+    return "Undefined";
+  }
 
-    const name = typeof entity.name !== "undefined"
-        ? entity.name : entity.extendedEntityName
+  const name = typeof entity.name !== "undefined"
+    ? entity.name : entity.extendedEntityName
 
-    return (
-        "<b>" +
-        name +
-        ":</b><i>" +
-        entity.typeString +
-        "</i>" +
-        "\n ----------------- \n" +
-        itemsString(entity.properties) +
-        "\n ----------------- \n" +
-        itemsString(entity.methods)
-    );
+  return (
+    "<b>" +
+    name +
+    ":</b><i>" +
+    entity.typeString +
+    "</i>" +
+    "\n ----------------- \n" +
+    itemsString(entity.properties) +
+    "\n ----------------- \n" +
+    itemsString(entity.methods)
+  );
 }
 
 function color(typeString) {
-    switch (typeString) {
-        case "class":
-            return colorClass;
-            break;
-        case "struct":
-            return colorStruct;
-            break;
-        case "enum":
-            return colorEnum;
-            break;
-        case "protocol":
-            return colorProtocol;
-            break;
-        case "extension":
-            return colorExtension;
-            break;
-        default:
-            return colorPinkErrorOccured;
-    }
+  switch (typeString) {
+    case "class":
+      return colorClass;
+      break;
+    case "struct":
+      return colorStruct;
+      break;
+    case "enum":
+      return colorEnum;
+      break;
+    case "protocol":
+      return colorProtocol;
+      break;
+    case "extension":
+      return colorExtension;
+      break;
+    default:
+      return colorPinkErrorOccured;
+  }
 }

--- a/htmltemplate/js/entity.js
+++ b/htmltemplate/js/entity.js
@@ -1,62 +1,65 @@
 
 // Fields and methods
 function itemsString(items) {
-  if (items == undefined || items.count <= 0) {
-    return "";
-  }
+    if (items == undefined || items.count <= 0) {
+        return "";
+    }
 
-  const result = items
-    .map(x => {
-      // UML private/public is denoted by +/-
-      const accessString = x.accessLevel == "public" ? "+" : "-";
+    const result = items
+        .map(x => {
+            // UML private/public is denoted by +/-
+            const accessString = x.accessLevel == "public" ? "+" : "-";
 
-      // UML static members and methods should be underlined
-      const nameString =
-        x.type == "instance" ? x.name : "_" + x.name.replace(/ /g, "_") + "_";
+            // UML static members and methods should be underlined
+            const nameString =
+                x.type == "instance" ? x.name : "_" + x.name.replace(/ /g, "_") + "_";
 
-      return accessString + " " + nameString;
-    })
-    .join("\n");
-  return result;
+            return accessString + " " + nameString;
+        })
+        .join("\n");
+    return result;
 }
 
 // { id: 3, font: { multi: 'html', size: 20 }, label: '<b>This</b> is an\n<i>html</i> <b><i>multi-</i>font</b> <code>label</code>', x: 40, y: 40 },
 function networkLabel(entity) {
-  if (entity == undefined) {
-    return "Undefined";
-  }
+    if (entity == undefined) {
+        return "Undefined";
+    }
 
-  return (
-    "<b>" +
-    entity.name +
-    ":</b><i>" +
-    entity.typeString +
-    "</i>" +
-    "\n ----------------- \n" +
-    itemsString(entity.properties) +
-    "\n ----------------- \n" +
-    itemsString(entity.methods)
-  );
+    const name = typeof entity.name !== "undefined"
+        ? entity.name : entity.extendedEntityName
+
+    return (
+        "<b>" +
+        name +
+        ":</b><i>" +
+        entity.typeString +
+        "</i>" +
+        "\n ----------------- \n" +
+        itemsString(entity.properties) +
+        "\n ----------------- \n" +
+        itemsString(entity.methods)
+    );
 }
 
 function color(typeString) {
-  switch (typeString) {
-    case "class":
-      return colorClass;
-      break;
-    case "struct":
-      return colorStruct;
-      break;
-    case "enum":
-      return colorEnum;
-      break;
-    case "protocol":
-      return colorProtocol;
-      break;
-    case "extension":
-      return colorExtension;
-      break;
-    default:
-      return colorPinkErrorOccured;
-  }
+    switch (typeString) {
+        case "class":
+            return colorClass;
+            break;
+        case "struct":
+            return colorStruct;
+            break;
+        case "enum":
+            return colorEnum;
+            break;
+        case "protocol":
+            return colorProtocol;
+            break;
+        case "extension":
+            return colorExtension;
+            break;
+        default:
+            return colorPinkErrorOccured;
+    }
 }

--- a/rubyResources/entityExtension.rb
+++ b/rubyResources/entityExtension.rb
@@ -6,4 +6,12 @@ class EntityExtension < Entity
 
     @extendedEntityName = extendedEntityName
   end
+
+  def to_json(*_args)
+    hash = to_hash
+
+    hash['extendedEntityName'] = @extendedEntityName
+    JSON.pretty_generate(hash)
+  end
+
 end


### PR DESCRIPTION
Added logic to the `networkLabel(entity)` method in entity.js to use `entity.extendedEntityName` instead of `entity.name` if `entity.name` is
undefined.

If you'd prefer to go in a different direction with this I'd be happy to make any changes you want. This was just my quick and dirty fix to get this working for myself and I figured I'd share.